### PR TITLE
feat(core): ability to compare two immutable structures

### DIFF
--- a/lib/reducerTest.js
+++ b/lib/reducerTest.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const deepFreeze = require('deep-freeze')
-const { is, Iterable: { isIterable } } = require('immutable')
+const Immutable = require('immutable')
+
+const isIterable = Immutable.Iterable.isIterable
 
 module.exports = (reducer, stateBefore, action, stateAfter, description) => t => {
   deepFreeze(action)
 
   if (isIterable(stateBefore) && isIterable(stateAfter)) {
-    return t.true(is(reducer(stateBefore, action), stateAfter), description)
+    return t.true(Immutable.is(reducer(stateBefore, action), stateAfter), description)
   }
 
   deepFreeze(stateBefore)

--- a/lib/reducerTest.js
+++ b/lib/reducerTest.js
@@ -1,10 +1,15 @@
 'use strict'
 
 const deepFreeze = require('deep-freeze')
+const { is, Iterable: { isIterable } } = require('immutable')
 
 module.exports = (reducer, stateBefore, action, stateAfter, description) => t => {
   deepFreeze(action)
-  deepFreeze(stateBefore)
 
+  if (isIterable(stateBefore) && isIterable(stateAfter)) {
+    return t.true(is(reducer(stateBefore, action), stateAfter), description)
+  }
+
+  deepFreeze(stateBefore)
   t.deepEqual(reducer(stateBefore, action), stateAfter, description)
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test"
   ],
   "dependencies": {
-    "deep-freeze": "0.0.1"
+    "deep-freeze": "0.0.1",
+    "immutable": "^3.8.1"
   },
   "devDependencies": {
     "cz-conventional-changelog": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "redux-ava",
   "description": "Write AVA tests for redux pretty quickly",
+  "version": "2.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi Juan! First, thanks for this port :smile: 

I thought it would be a good idea to implement the ability to compare two immutable structures, since using redux with immutable is a common pattern that tend to grow.

The only potential issue is that it require to add the `immutable` dependency, to both check if passed states are immutable iterables, and to compare them. But it shouldn't be too much of a problem, since `redux-ava` is supposed to be installed only in development anyway.

I've decided to deep-freeze only the action in case both states are immutables, since the previous state would be inevitably immutable.

Let me know your thoughts about this!